### PR TITLE
Support Julia 0.5, enable tests on nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - release
+  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/src/Row.jl
+++ b/src/Row.jl
@@ -23,8 +23,8 @@ end
 
 @generated Row{Index<:FieldIndex,DataTypes<:Tuple}(::Index,data_in::DataTypes) = :(Row{$(Index()),$DataTypes}(data_in))
 Row{Index<:FieldIndex}(::Index, data_in...) = error("Must instantiate Row with a tuple of type $(eltypes(Index))")
-@generated Base.call{Index<:FieldIndex,DataTypes<:Tuple}(::Index,x::DataTypes) = :(Row{$(Index()),$DataTypes}(x))
-Base.call{Index<:FieldIndex}(::Index,x...) = error("Must instantiate Row with a tuple of type $(eltypes(Index))")
+@generated Base.call{F,DataTypes<:Tuple}(::FieldIndex{F},x::DataTypes) = :(Row{$(FieldIndex{F}()),$DataTypes}(x))
+Base.call{F}(::FieldIndex{F},x...) = error("Must instantiate Row with a tuple of type $(eltypes(FieldIndex{F}()))")
 
 @generated function check_row{Index<:FieldIndex,DataTypes<:Tuple}(::Index,::Type{DataTypes})
     if eltypes(Index()) != DataTypes


### PR DESCRIPTION
Since you mentioned possible features only available in Julia 0.5, I gave it a try and noticed the package doesn't load. This fixes it (and the tests pass).

There are still warnings about the deprecated `call` syntax, but AFAICT Compat.jl does not support this yet (which is a bit surprising, but that's not essential).